### PR TITLE
refactor: memoized analyzer construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 - String matching specialization #4
 - Optimize construction of a batch of documents for matching #5
 - Bump lt.jocas/lucene-custom-analyzer to 1.0.34
+- refactor: memoized analyzer construction (#9)
 
 ## 1.0.2 (2023-08-31)
 

--- a/src/lucene/monitor/analyzer.clj
+++ b/src/lucene/monitor/analyzer.clj
@@ -1,0 +1,6 @@
+(ns lucene.monitor.analyzer
+  (:require [lucene.custom.analyzer :as a]))
+
+(def create
+  "Memoized version of the analyzer creation."
+  (memoize a/create))

--- a/src/lucene/monitor/queries.clj
+++ b/src/lucene/monitor/queries.clj
@@ -1,7 +1,7 @@
 (ns lucene.monitor.queries
   (:require [clojure.java.io :as io]
             [lucene.custom.query :as q]
-            [lucene.custom.analyzer :as a]
+            [lucene.monitor.analyzer :as a]
             [lucene.monitor.print :as print]
             [lucene.monitor.serde :as serde])
   (:import (java.util HashMap Map)

--- a/src/lucene/monitor/setup.clj
+++ b/src/lucene/monitor/setup.clj
@@ -1,5 +1,5 @@
 (ns lucene.monitor.setup
-  (:require [lucene.custom.analyzer :as analyzer]
+  (:require [lucene.monitor.analyzer :as analyzer]
             [lucene.monitor.queries :as queries])
   (:import (java.nio.file Path)
            (java.util Map)


### PR DESCRIPTION
Every query creates its own analyzer.
Most queries are expected to have the same analysis conf, i.e. no conf.
Analyzers are threadsafe.

#8 
