### PR TITLE
Fix/per field analyzer wrapper use in query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 - refactor: memoized analyzer construction (#9)
 - feat: support for nested documents (#10)
 - feat: match mode `:explain` to explain the match score #11
+- Query parser uses `PerFieldAnalyzerWrapper` #12
 
 ## 1.0.2 (2023-08-31)
 

--- a/src/lucene/monitor/analyzer.clj
+++ b/src/lucene/monitor/analyzer.clj
@@ -1,6 +1,33 @@
 (ns lucene.monitor.analyzer
-  (:require [lucene.custom.analyzer :as a]))
+  (:require [lucene.custom.analyzer :as a])
+  (:import (java.util HashMap Map Map$Entry)
+           (org.apache.lucene.analysis Analyzer)
+           (org.apache.lucene.analysis.miscellaneous PerFieldAnalyzerWrapper)))
 
 (def create
   "Memoized version of the analyzer creation."
   (memoize a/create))
+
+(defn ->per-field-analyzer-wrapper
+  "Creates a PerFieldAnalyzerWrapper.
+  TIP: if field->analyzer is mutable, mutations can be done after the creation
+  are going to be visible for analysis.
+  Params:
+  * default: default Analyzer object,
+  * field->analyzer: Map<String, Analyzer>"
+  ^Analyzer [^Analyzer default ^Map field->analyzer]
+  (PerFieldAnalyzerWrapper. default field->analyzer))
+
+(defn prepare->per-field-analyzer-wrapper
+  "Constructs a PerFieldAnalyzerWrapper.
+  Tip: in case you use
+  Params:
+  * default: a default analyzer configuration
+  * field->analyzer: a map from field name to the analyzer configuration"
+  [default ^Map field->analyzer]
+  (let [default-analyzer (create default)
+        f->a (reduce (fn add-to-mapping! [^Map mapping ^Map$Entry kv]
+                       (doto mapping (.put (name (.getKey kv)) (create (.getValue kv)))))
+                     (HashMap.)
+                     (.entrySet field->analyzer))]
+    (->per-field-analyzer-wrapper default-analyzer f->a)))

--- a/src/lucene/monitor/setup.clj
+++ b/src/lucene/monitor/setup.clj
@@ -5,7 +5,6 @@
            (java.util Map)
            (java.util.concurrent ConcurrentHashMap)
            (java.util.function Function)
-           (org.apache.lucene.analysis.miscellaneous PerFieldAnalyzerWrapper)
            (org.apache.lucene.analysis.standard StandardAnalyzer)
            (org.apache.lucene.monitor Monitor MonitorConfiguration MonitorQuerySerializer
                                       MultipassTermFilteredPresearcher Presearcher
@@ -26,12 +25,14 @@
 
 (defn ->maintain-mapping-fn
   "Returns a single arg function that wraps over a mutable Map of field->analyzer mapping.
-  When called and if field is missing creates an analyzer."
+  When called the fn checks if field is missing, then creates an analyzer, adds it to the
+  mapping, and returns the (mutable!) mapping."
   [^Map field->analyzer]
   (fn add-when-missing! [query]
-    (.computeIfAbsent field->analyzer
-                      (:default-field query)
-                      (reify Function (apply [_ _] (analyzer/create (:analyzer query)))))))
+    (doto field->analyzer
+      (.computeIfAbsent
+        (:default-field query)
+        (reify Function (apply [_ _] (analyzer/create (:analyzer query))))))))
 
 (def DEFAULT_ANALYZER (StandardAnalyzer.))
 

--- a/src/lucene/monitor/setup.clj
+++ b/src/lucene/monitor/setup.clj
@@ -27,9 +27,9 @@
 (defn ->maintain-mapping-fn
   "Returns a single arg function that wraps over a mutable Map of field->analyzer mapping.
   When called and if field is missing creates an analyzer."
-  [^Map field-name->lucene-analyzer]
+  [^Map field->analyzer]
   (fn add-when-missing! [query]
-    (.computeIfAbsent field-name->lucene-analyzer
+    (.computeIfAbsent field->analyzer
                       (:default-field query)
                       (reify Function (apply [_ _] (analyzer/create (:analyzer query)))))))
 
@@ -82,10 +82,10 @@
 (defn monitor
   "Creates a Monitor object.
   If :index-path is specified then loads field->Analyzer from the index."
-  [options default-query-analyzer field-name->lucene-analyzer maintain-field->analyzer-fn]
+  [options default-query-analyzer field->analyzer maintain-field->analyzer-fn]
   (let [default-field-analyzer (or-default-analyzer (:default-field-analyzer options))]
-    (Monitor. (PerFieldAnalyzerWrapper. default-field-analyzer
-                                        field-name->lucene-analyzer)
+    (Monitor. (analyzer/->per-field-analyzer-wrapper default-field-analyzer
+                                                     field->analyzer)
               (presearcher (:presearcher options))
               (monitor-configuration options
                                      default-query-analyzer

--- a/src/lucene/monitor/setup.clj
+++ b/src/lucene/monitor/setup.clj
@@ -16,8 +16,7 @@
 (set! *warn-on-reflection* true)
 
 (defn init-analyzer-mapping!
-  "Creates field analyzers from the schema.
-  Makes sure the schema file exists, and if already exists then loads mapping."
+  "Creates field analyzers from the schema."
   [options]
   (let [field->analyzer (ConcurrentHashMap.)]
     (when-let [schema (:schema options)]


### PR DESCRIPTION
This makes parts of query to be analyzed according to the field analysis setup.

E.g. if a schema field `that-field` has some analyzer, then in query `that-field: query_term` `query_term` will be analyzed with that analyzer.

```clojure
(str 
  (let [fields {"a"  (lucene.custom.analyzer/create {:token-filters [:reverseString]})
                "FF" (lucene.custom.analyzer/create {:token-filters [:uppercase]})}]
    (lucene.custom.query/parse
      "a:\"foo qux\" FF: bar 12345"
      :classic
      {}
      "default"
      (PerFieldAnalyzerWrapper.
        (lucene.custom.analyzer/create {:token-filters [{:edgeNGram {:minGramSize 3 :maxGramSize 10}}]})
        fields))))
;=> "a:\"oof xuq\" FF:BAR Synonym(default:123 default:1234 default:12345)"
```